### PR TITLE
added memory cache to avoid constant refetching

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,14 +2,19 @@
 const MOON = '<i class="fas fa-moon"></i>';
 const SUN = '<i class="fas fa-sun"></i>';
 let toggleCount = 0; // Counter to track the number of clicks
+let cachedContributors = null;
 
 // Function to load participants from the JSON file
 async function loadContributors() {
+    if (cachedContributors !== null) {
+        return cachedContributors;
+    }
     let contributors = null;
     showLoadingScreen();
     try {
         const response = await fetch("contributors.json");
         contributors = await response.json();
+        cachedContributors = contributors;
     } catch (error) {
         console.log(error);
     } finally {


### PR DESCRIPTION
@JollyJolli I noticed constant flickering of the loading screen due to the fetch function being called with each search. To smooth that out I added this memory cache variable so that it does not need to constantly refetch. This is a quick and easy solution especially with the possible constant changes to the json.